### PR TITLE
Update to make plugin work with GoCD 17.1 and above

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1,6 +1,5 @@
 <project name="go-maven-poller" default="all" basedir="." xmlns:ivy="antlib:org.apache.ivy.ant">
 
-    <property name="go.plugin.api" value="sdk/go-plugin-api-13.3.0.jar"/>
     <property name="go.plugin.util" value="sdk/go-plugin-util.jar"/>
     <property name="target.dir" value="target"/>
     <property name="dist.dir" value="dist"/>
@@ -10,7 +9,6 @@
         <fileset dir="lib">
             <include name="**/*.jar"/>
         </fileset>
-        <pathelement location="${go.plugin.api}"/>
         <pathelement location="${go.plugin.util}"/>
     </path>
     <target name="resolve">
@@ -70,9 +68,10 @@
                 <exclude name="hamcrest*.jar"/>
                 <exclude name="*-sources.jar"/>
                 <exclude name="*-javadoc.jar"/>
+                <exclude name="go-plugin-api*.jar"/>
                 <include name="*.jar"/>
             </fileset>
-            <file file="sdk/go-plugin-util.jar"/>
+            <file file="${go.plugin.util}"/>
         </copy>
         <basename property="jar.name" file="${basedir}"/>
         <copy file="plugin.xml" todir="${target.dir}/src"/>

--- a/ivy.xml
+++ b/ivy.xml
@@ -7,10 +7,11 @@
         <dependency org="org.apache.httpcomponents" name="httpclient" rev="4.2.5"/>
         <dependency org="org.apache.httpcomponents" name="httpcore" rev="4.2.4"/>
         <dependency org="org.jsoup" name="jsoup" rev="1.8.1" />
+        <dependency org="com.google.code.gson" name="gson" rev="2.3.1" />
+        <dependency org="cd.go.plugin" name="gocd-package-material-plugin-shim" rev="16.12.0" />
+
         <dependency org="junit" name="junit" rev="4.11"/>
         <dependency org="org.mockito" name="mockito-all" rev="1.9.5"/>
-        <dependency org="com.thoughtworks" name="go-plugin-api" rev="current">
-           <artifact name="go-plugin-api" url="http://www.thoughtworks.com/products/docs/go/current/help/resources/go-plugin-api-current.jar"/>
-        </dependency>
+        <dependency org="cd.go.plugin" name="go-plugin-api" rev="16.11.0"/>
     </dependencies>
 </ivy-module>

--- a/src/com/tw/go/plugin/maven/apimpl/MavenProvider.java
+++ b/src/com/tw/go/plugin/maven/apimpl/MavenProvider.java
@@ -5,7 +5,6 @@ import com.thoughtworks.go.plugin.api.material.packagerepository.PackageMaterial
 import com.thoughtworks.go.plugin.api.material.packagerepository.PackageMaterialPoller;
 import com.thoughtworks.go.plugin.api.material.packagerepository.PackageMaterialProvider;
 
-@Extension
 public class MavenProvider implements PackageMaterialProvider {
 
     public PackageMaterialConfiguration getConfig() {

--- a/src/com/tw/go/plugin/maven/apimpl/NewPackageMaterialProvider.java
+++ b/src/com/tw/go/plugin/maven/apimpl/NewPackageMaterialProvider.java
@@ -1,0 +1,33 @@
+package com.tw.go.plugin.maven.apimpl;
+
+import com.thoughtworks.go.plugin.api.GoApplicationAccessor;
+import com.thoughtworks.go.plugin.api.GoPlugin;
+import com.thoughtworks.go.plugin.api.GoPluginIdentifier;
+import com.thoughtworks.go.plugin.api.annotation.Extension;
+import com.thoughtworks.go.plugin.api.exceptions.UnhandledRequestTypeException;
+import com.thoughtworks.go.plugin.api.material.packagerepository.shim.ReplacementProvider;
+import com.thoughtworks.go.plugin.api.request.GoPluginApiRequest;
+import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
+
+@Extension
+public class NewPackageMaterialProvider implements GoPlugin {
+    private ReplacementProvider replacementProvider;
+
+    public NewPackageMaterialProvider() {
+        replacementProvider = new ReplacementProvider(new MavenProvider());
+    }
+
+    @Override
+    public GoPluginApiResponse handle(GoPluginApiRequest goPluginApiRequest) throws UnhandledRequestTypeException {
+        return replacementProvider.handle(goPluginApiRequest);
+    }
+
+    @Override
+    public GoPluginIdentifier pluginIdentifier() {
+        return replacementProvider.pluginIdentifier();
+    }
+
+    @Override
+    public void initializeGoApplicationAccessor(GoApplicationAccessor goApplicationAccessor) {
+    }
+}


### PR DESCRIPTION
Using the [plugin shim](https://github.com/gocd-contrib/gocd-package-material-plugin-shim) to upgrade this plugin, so that it works with 17.1. Without this change, this plugin will stop working from GoCD 17.1 onwards.